### PR TITLE
Add Moonshot Kimi K2 model

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   ],
   "activationEvents": [
     "onCommand:superdesign.helloWorld",
-    "onView:superdesign.chatView"
+    "onView:superdesign.chatView",
+    "onCommand:superdesign.configureMoonshotApiKey"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -61,6 +62,11 @@
       {
         "command": "superdesign.configureOpenRouterApiKey",
         "title": "Configure OpenRouter API Key",
+        "category": "Superdesign"
+      },
+      {
+        "command": "superdesign.configureMoonshotApiKey",
+        "title": "Configure Moonshot API Key",
         "category": "Superdesign"
       },
       {
@@ -153,15 +159,21 @@
           "description": "OpenRouter API key for custom agent",
           "scope": "application"
         },
+        "superdesign.moonshotApiKey": {
+          "type": "string",
+          "description": "Moonshot (Kimi) API key for custom agent",
+          "scope": "application"
+        },
         "superdesign.aiModelProvider": {
           "type": "string",
           "enum": [
             "openai",
             "anthropic",
-            "openrouter"
+            "openrouter",
+            "moonshot"
           ],
           "default": "anthropic",
-          "description": "AI model provider for custom agent (OpenAI, Anthropic, or OpenRouter)",
+          "description": "AI model provider for custom agent (OpenAI, Anthropic, OpenRouter or Moonshot)",
           "scope": "application"
         },
         "superdesign.aiModel": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1270,9 +1270,13 @@ export function activate(context: vscode.ExtensionContext) {
 		await configureOpenAIApiKey();
 	});
 
-	const configureOpenRouterApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureOpenRouterApiKey', async () => {
-		await configureOpenRouterApiKey();
-	});
+        const configureOpenRouterApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureOpenRouterApiKey', async () => {
+                await configureOpenRouterApiKey();
+        });
+
+        const configureMoonshotApiKeyDisposable = vscode.commands.registerCommand('superdesign.configureMoonshotApiKey', async () => {
+                await configureMoonshotApiKey();
+        });
 
 
 	// Create the chat sidebar provider
@@ -1390,9 +1394,10 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		helloWorldDisposable, 
 		configureApiKeyDisposable,
-		configureOpenAIApiKeyDisposable,
-		configureOpenRouterApiKeyDisposable,
-		sidebarDisposable,
+                configureOpenAIApiKeyDisposable,
+                configureOpenRouterApiKeyDisposable,
+                configureMoonshotApiKeyDisposable,
+                sidebarDisposable,
 		showSidebarDisposable,
 		openCanvasDisposable,
 		clearChatDisposable,
@@ -1536,6 +1541,48 @@ async function configureOpenRouterApiKey() {
 			vscode.window.showWarningMessage('No API key was set');
 		}
 	}
+}
+
+// Function to configure Moonshot API key
+async function configureMoonshotApiKey() {
+        const currentKey = vscode.workspace.getConfiguration('superdesign').get<string>('moonshotApiKey');
+
+        const input = await vscode.window.showInputBox({
+                title: 'Configure Moonshot API Key',
+                prompt: 'Enter your Moonshot API key (get one from https://platform.moonshot.ai/)',
+                value: currentKey ? '••••••••••••••••' : '',
+                password: true,
+                placeHolder: 'sk-...',
+                validateInput: (value) => {
+                        if (!value || value.trim().length === 0) {
+                                return 'API key cannot be empty';
+                        }
+                        if (value === '••••••••••••••••') {
+                                return null; // User didn't change the masked value, that's OK
+                        }
+                        return null;
+                }
+        });
+
+        if (input !== undefined) {
+                // Only update if user didn't just keep the masked value
+                if (input !== '••••••••••••••••') {
+                        try {
+                                await vscode.workspace.getConfiguration('superdesign').update(
+                                        'moonshotApiKey',
+                                        input.trim(),
+                                        vscode.ConfigurationTarget.Global
+                                );
+                                vscode.window.showInformationMessage('✅ Moonshot API key configured successfully!');
+                        } catch (error) {
+                                vscode.window.showErrorMessage(`Failed to save API key: ${error}`);
+                        }
+                } else if (currentKey) {
+                        vscode.window.showInformationMessage('API key unchanged (already configured)');
+                } else {
+                        vscode.window.showWarningMessage('No API key was set');
+                }
+        }
 }
 
 class SuperdesignCanvasPanel {

--- a/src/providers/chatSidebarProvider.ts
+++ b/src/providers/chatSidebarProvider.ts
@@ -109,6 +109,9 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             case 'openrouter':
                 defaultModel = 'anthropic/claude-3-7-sonnet-20250219';
                 break;
+            case 'moonshot':
+                defaultModel = 'kimi-k2-0711-preview';
+                break;
             case 'anthropic':
             default:
                 defaultModel = 'claude-3-5-sonnet-20241022';
@@ -143,6 +146,11 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
                 apiKeyKey = 'anthropicApiKey';
                 configureCommand = 'superdesign.configureApiKey';
                 displayName = `Anthropic (${this.getModelDisplayName(model)})`;
+            } else if (model.startsWith('kimi-')) {
+                provider = 'moonshot';
+                apiKeyKey = 'moonshotApiKey';
+                configureCommand = 'superdesign.configureMoonshotApiKey';
+                displayName = `Kimi (${this.getModelDisplayName(model)})`;
             } else {
                 provider = 'openai';
                 apiKeyKey = 'openaiApiKey';
@@ -189,6 +197,7 @@ export class ChatSidebarProvider implements vscode.WebviewViewProvider {
             'gpt-4.1-nano': 'GPT-4.1 Nano',
             'gpt-4o': 'GPT-4o',
             'gpt-4o-mini': 'GPT-4o Mini',
+            'kimi-k2-0711-preview': 'Kimi K2',
             // Anthropic models
             'claude-4-opus-20250514': 'Claude 4 Opus',
             'claude-4-sonnet-20250514': 'Claude 4 Sonnet',

--- a/src/services/chatMessageService.ts
+++ b/src/services/chatMessageService.ts
@@ -142,6 +142,8 @@ export class ChatMessageService {
                         effectiveProvider = 'openrouter';
                     } else if (specificModel.startsWith('claude-')) {
                         effectiveProvider = 'anthropic';
+                    } else if (specificModel.startsWith('kimi-')) {
+                        effectiveProvider = 'moonshot';
                     } else {
                         effectiveProvider = 'openai';
                     }
@@ -155,6 +157,10 @@ export class ChatMessageService {
                     case 'anthropic':
                         providerName = 'Anthropic';
                         configureCommand = 'superdesign.configureApiKey';
+                        break;
+                    case 'moonshot':
+                        providerName = 'Kimi';
+                        configureCommand = 'superdesign.configureMoonshotApiKey';
                         break;
                     case 'openai':
                         providerName = 'OpenAI';

--- a/src/services/customAgentService.ts
+++ b/src/services/customAgentService.ts
@@ -94,6 +94,8 @@ export class CustomAgentService implements AgentService {
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
+            } else if (specificModel.startsWith('kimi-')) {
+                effectiveProvider = 'moonshot';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -116,6 +118,23 @@ export class CustomAgentService implements AgentService {
                 const openrouterModel = specificModel || 'anthropic/claude-3-7-sonnet-20250219';
                 this.outputChannel.appendLine(`Using OpenRouter model: ${openrouterModel}`);
                 return openrouter.chat(openrouterModel);
+
+            case 'moonshot':
+                const moonshotKey = config.get<string>('moonshotApiKey');
+                if (!moonshotKey) {
+                    throw new Error('Moonshot API key not configured. Please run "Configure Moonshot API Key" command.');
+                }
+
+                this.outputChannel.appendLine(`Moonshot API key found: ${moonshotKey.substring(0, 12)}...`);
+
+                const moonshot = createOpenAI({
+                    apiKey: moonshotKey,
+                    baseURL: 'https://api.moonshot.ai/v1'
+                });
+
+                const moonshotModel = specificModel || 'kimi-k2-0711-preview';
+                this.outputChannel.appendLine(`Using Moonshot model: ${moonshotModel}`);
+                return moonshot(moonshotModel);
                 
             case 'anthropic':
                 const anthropicKey = config.get<string>('anthropicApiKey');
@@ -179,6 +198,9 @@ export class CustomAgentService implements AgentService {
                     break;
                 case 'openrouter':
                     modelName = 'anthropic/claude-3-7-sonnet-20250219';
+                    break;
+                case 'moonshot':
+                    modelName = 'kimi-k2-0711-preview';
                     break;
                 case 'anthropic':
                 default:
@@ -895,6 +917,8 @@ I've created the html design, please reveiw and let me know if you need any chan
                 effectiveProvider = 'openrouter';
             } else if (specificModel.startsWith('claude-')) {
                 effectiveProvider = 'anthropic';
+            } else if (specificModel.startsWith('kimi-')) {
+                effectiveProvider = 'moonshot';
             } else {
                 effectiveProvider = 'openai';
             }
@@ -905,6 +929,8 @@ I've created the html design, please reveiw and let me know if you need any chan
                 return !!config.get<string>('openrouterApiKey');
             case 'anthropic':
                 return !!config.get<string>('anthropicApiKey');
+            case 'moonshot':
+                return !!config.get<string>('moonshotApiKey');
             case 'openai':
             default:
                 return !!config.get<string>('openaiApiKey');

--- a/src/webview/components/Chat/ChatInterface.tsx
+++ b/src/webview/components/Chat/ChatInterface.tsx
@@ -57,6 +57,9 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ layout, vscode }) => {
                     case 'openrouter':
                         fallbackModel = 'anthropic/claude-3-7-sonnet-20250219';
                         break;
+                    case 'moonshot':
+                        fallbackModel = 'kimi-k2-0711-preview';
+                        break;
                     case 'anthropic':
                     default:
                         fallbackModel = 'claude-3-5-sonnet-20241022';

--- a/src/webview/components/Chat/ModelSelector.tsx
+++ b/src/webview/components/Chat/ModelSelector.tsx
@@ -55,7 +55,9 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ selectedModel, onModelCha
         { id: 'rekaai/reka-flash-3', name: 'Reka Flash 3', provider: 'OpenRouter (Reka)', category: 'Balanced' },
         // Existing OpenAI (direct)
         { id: 'gpt-4.1', name: 'GPT-4.1', provider: 'OpenAI', category: 'Balanced' },
-        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' }
+        { id: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', provider: 'OpenAI', category: 'Fast' },
+        // Moonshot
+        { id: 'kimi-k2-0711-preview', name: 'Kimi K2', provider: 'Kimi', category: 'Balanced' }
     ];
 
     const filteredModels = models.filter(model =>


### PR DESCRIPTION
## Summary
- add configuration and command for Moonshot API key
- support new `moonshot` provider in backend services
- show Kimi K2 model in model selector dropdown
- handle Moonshot models in chat UI

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6880aa6114f48328be2856a8a4522471